### PR TITLE
Pin esp-zboss-lib to 1.5.1

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/esp-zboss-lib: 
-    version: "^1.5.1"
+    version: "==1.5.1"
   
   ## Required IDF version
   idf:


### PR DESCRIPTION
A fresh build pulls `esp-zboss-lib` 1.6.4, and the build fails. This PR pins `esp-zboss-lib` to 1.5.1, rather than allowing higher minor and patch versions via `^1.5.1`